### PR TITLE
[AArch64][WinCFI] Handle cases where no SEH opcodes in the prologue

### DIFF
--- a/llvm/test/CodeGen/AArch64/wincfi-seh-only-in-epilogue.ll
+++ b/llvm/test/CodeGen/AArch64/wincfi-seh-only-in-epilogue.ll
@@ -1,0 +1,13 @@
+; RUN: llc -mtriple=aarch64-windows %s -o - | FileCheck %s
+
+define hidden swifttailcc void @test(ptr noalias nocapture %0, ptr swiftasync %1, ptr %2, ptr noalias nocapture %3, ptr nocapture dereferenceable(8) %4, ptr %5, ptr %6, ptr %Act, ptr %Err, ptr %Res, ptr %Act.DistributedActor, ptr %Err.Error, ptr %Res.Decodable, ptr %Res.Encodable, ptr swiftself %7) #0 {
+entry:
+  ret void
+}
+
+; Check that there is no .seh_endprologue but there is seh_startepilogue/seh_endepilogue.
+; CHECK-NOT: .seh_endprologue
+; CHECK:     .seh_startepilogue
+; CHECK:     add sp, sp, #48
+; CHECK:     .seh_stackalloc 48
+; CHECK:     .seh_endepilogue


### PR DESCRIPTION
but there are some in the epilogue.

Make a decision whether or not to have a startepilogue/endepilogue
based on whether we actually insert SEH opcodes in the epilogue,
rather than whether we had SEH opcodes in the prologue or not.

This fixes an assert failure when there are no SEH opcodes in the
prologue but there are SEH opcodes in the epilogue (for example, when
there is no stack frame but there are stack arguments) which was not
covered in https://reviews.llvm.org/D88641.

Assertion failed: HasWinCFI == MF.hasWinCFI(), file C:\Users\hiroshi\llvm-project\llvm\lib\Target\AArch64\AArch64FrameLowering.cpp, line 1988

Differential Revision: https://reviews.llvm.org/D159238

---

**Stack**:
- #6
- #5
- #4


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*