### PR TITLE
[mlir][doc] fix document link in Builtin Dialect document

### DIFF
--- a/mlir/include/mlir/IR/BuiltinTypes.td
+++ b/mlir/include/mlir/IR/BuiltinTypes.td
@@ -913,7 +913,7 @@ def Builtin_UnrankedMemRef : Builtin_Type<"UnrankedMemRef", [
     arguments of any rank without versioning the functions based on the rank.
     Other uses of this type are disallowed or will have undefined behavior.
 
-    See [MemRefType](#builtin_memref-memreftype) for more information on
+    See [MemRefType](#memreftype) for more information on
     memref types.
 
     Examples:
@@ -986,7 +986,7 @@ def Builtin_UnrankedTensor : Builtin_Type<"UnrankedTensor", [
     ```
 
     An unranked tensor is a type of tensor in which the set of dimensions have
-    unknown rank. See [RankedTensorType](#builtin_rankedtensor-rankedtensortype)
+    unknown rank. See [RankedTensorType](#rankedtensortype)
     for more information on tensor types.
 
     Examples:


### PR DESCRIPTION
The inline link to RankedTensorType in UnrankedTensorType section
and the inline link to MemRefType in UnrankedMemrefType section
are all invalid. This patch update these link.

Reviewed By: aartbik

Differential Revision: https://reviews.llvm.org/D152682

---

**Stack**:
- #20
- #19
- #18
- #17
- #16
- #15
- #14
- #13
- #6
- #5
- #4


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*